### PR TITLE
Run performance tests in Release config

### DIFF
--- a/LastMile.xcodeproj/xcshareddata/xcbaselines/036F0261229F12E200991283.xcbaseline/FEF9307A-D6B7-4D22-8928-163CC0C2A5BD.plist
+++ b/LastMile.xcodeproj/xcshareddata/xcbaselines/036F0261229F12E200991283.xcbaseline/FEF9307A-D6B7-4D22-8928-163CC0C2A5BD.plist
@@ -1,0 +1,132 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>classNames</key>
+	<dict>
+		<key>CollectionTests</key>
+		<dict>
+			<key>test_LastMileArray100()</key>
+			<dict>
+				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
+				<dict>
+					<key>baselineAverage</key>
+					<real>0.0024546</real>
+					<key>baselineIntegrationDisplayName</key>
+					<string>Apr 22, 2020 at 1:01:31 PM</string>
+				</dict>
+			</dict>
+			<key>test_LastMileArray1000()</key>
+			<dict>
+				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
+				<dict>
+					<key>baselineAverage</key>
+					<real>0.020446</real>
+					<key>baselineIntegrationDisplayName</key>
+					<string>Apr 22, 2020 at 1:01:31 PM</string>
+				</dict>
+			</dict>
+			<key>test_LastMileArray10000()</key>
+			<dict>
+				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
+				<dict>
+					<key>baselineAverage</key>
+					<real>0.21666</real>
+					<key>baselineIntegrationDisplayName</key>
+					<string>Apr 22, 2020 at 1:01:31 PM</string>
+				</dict>
+			</dict>
+			<key>test_LastMileDict100()</key>
+			<dict>
+				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
+				<dict>
+					<key>baselineAverage</key>
+					<real>0.0027059</real>
+					<key>baselineIntegrationDisplayName</key>
+					<string>Apr 22, 2020 at 1:01:31 PM</string>
+				</dict>
+			</dict>
+			<key>test_LastMileDict1000()</key>
+			<dict>
+				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
+				<dict>
+					<key>baselineAverage</key>
+					<real>0.022571</real>
+					<key>baselineIntegrationDisplayName</key>
+					<string>Apr 22, 2020 at 1:01:31 PM</string>
+				</dict>
+			</dict>
+			<key>test_LastMileDict10000()</key>
+			<dict>
+				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
+				<dict>
+					<key>baselineAverage</key>
+					<real>0.24293</real>
+					<key>baselineIntegrationDisplayName</key>
+					<string>Apr 22, 2020 at 1:01:31 PM</string>
+				</dict>
+			</dict>
+			<key>test_SwiftArray100()</key>
+			<dict>
+				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
+				<dict>
+					<key>baselineAverage</key>
+					<real>0.00098198</real>
+					<key>baselineIntegrationDisplayName</key>
+					<string>Apr 22, 2020 at 1:01:31 PM</string>
+				</dict>
+			</dict>
+			<key>test_SwiftArray1000()</key>
+			<dict>
+				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
+				<dict>
+					<key>baselineAverage</key>
+					<real>0.0095945</real>
+					<key>baselineIntegrationDisplayName</key>
+					<string>Apr 22, 2020 at 1:01:31 PM</string>
+				</dict>
+			</dict>
+			<key>test_SwiftArray10000()</key>
+			<dict>
+				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
+				<dict>
+					<key>baselineAverage</key>
+					<real>0.10155</real>
+					<key>baselineIntegrationDisplayName</key>
+					<string>Apr 22, 2020 at 1:01:31 PM</string>
+				</dict>
+			</dict>
+			<key>test_SwiftDict100()</key>
+			<dict>
+				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
+				<dict>
+					<key>baselineAverage</key>
+					<real>0.0013568</real>
+					<key>baselineIntegrationDisplayName</key>
+					<string>Apr 22, 2020 at 1:01:31 PM</string>
+				</dict>
+			</dict>
+			<key>test_SwiftDict1000()</key>
+			<dict>
+				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
+				<dict>
+					<key>baselineAverage</key>
+					<real>0.012601</real>
+					<key>baselineIntegrationDisplayName</key>
+					<string>Apr 22, 2020 at 1:01:31 PM</string>
+				</dict>
+			</dict>
+			<key>test_SwiftDict10000()</key>
+			<dict>
+				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
+				<dict>
+					<key>baselineAverage</key>
+					<real>0.12376</real>
+					<key>baselineIntegrationDisplayName</key>
+					<string>Apr 22, 2020 at 1:01:31 PM</string>
+				</dict>
+			</dict>
+		</dict>
+	</dict>
+</dict>
+</plist>

--- a/LastMile.xcodeproj/xcshareddata/xcbaselines/036F0261229F12E200991283.xcbaseline/Info.plist
+++ b/LastMile.xcodeproj/xcshareddata/xcbaselines/036F0261229F12E200991283.xcbaseline/Info.plist
@@ -66,6 +66,37 @@
 				<string>com.apple.platform.iphonesimulator</string>
 			</dict>
 		</dict>
+		<key>FEF9307A-D6B7-4D22-8928-163CC0C2A5BD</key>
+		<dict>
+			<key>localComputer</key>
+			<dict>
+				<key>busSpeedInMHz</key>
+				<integer>100</integer>
+				<key>cpuCount</key>
+				<integer>1</integer>
+				<key>cpuKind</key>
+				<string>Quad-Core Intel Core i7</string>
+				<key>cpuSpeedInMHz</key>
+				<integer>2300</integer>
+				<key>logicalCPUCoresPerPackage</key>
+				<integer>8</integer>
+				<key>modelCode</key>
+				<string>Macmini6,2</string>
+				<key>physicalCPUCoresPerPackage</key>
+				<integer>4</integer>
+				<key>platformIdentifier</key>
+				<string>com.apple.platform.macosx</string>
+			</dict>
+			<key>targetArchitecture</key>
+			<string>x86_64</string>
+			<key>targetDevice</key>
+			<dict>
+				<key>modelCode</key>
+				<string>iPhone8,4</string>
+				<key>platformIdentifier</key>
+				<string>com.apple.platform.iphonesimulator</string>
+			</dict>
+		</dict>
 	</dict>
 </dict>
 </plist>

--- a/LastMile.xcodeproj/xcshareddata/xcschemes/LastMilePerformanceTests.xcscheme
+++ b/LastMile.xcodeproj/xcshareddata/xcschemes/LastMilePerformanceTests.xcscheme
@@ -7,9 +7,9 @@
       buildImplicitDependencies = "YES">
    </BuildAction>
    <TestAction
-      buildConfiguration = "Debug"
-      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
-      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      buildConfiguration = "Release"
+      selectedDebuggerIdentifier = ""
+      selectedLauncherIdentifier = "Xcode.IDEFoundation.Launcher.PosixSpawn"
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
@@ -24,11 +24,9 @@
             </BuildableReference>
          </TestableReference>
       </Testables>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </TestAction>
    <LaunchAction
-      buildConfiguration = "Debug"
+      buildConfiguration = "Release"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"
@@ -37,8 +35,6 @@
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"
@@ -48,7 +44,7 @@
       debugDocumentVersioning = "YES">
    </ProfileAction>
    <AnalyzeAction
-      buildConfiguration = "Debug">
+      buildConfiguration = "Release">
    </AnalyzeAction>
    <ArchiveAction
       buildConfiguration = "Release"

--- a/LastMile/APIDecodableTypes/Dictionary+APIDecodable.swift
+++ b/LastMile/APIDecodableTypes/Dictionary+APIDecodable.swift
@@ -34,7 +34,7 @@ extension Dictionary: APIDecodable where Key == String, Value: APIDecodable {
             decoder.recordError(error)
             return nil
         }
-        let pairs: [(String, Value)] = jsonDict.compactMap { (key, _) in
+        let pairs: [(String, Value)] = jsonDict.keys.compactMap { key in
             let newDecoder = decoder[key]
             guard let value = newDecoder.decodeRequired(Value.self) else { return nil }
             return (key, value)

--- a/LastMile/Public/JSONContents.swift
+++ b/LastMile/Public/JSONContents.swift
@@ -46,7 +46,7 @@ extension JSONContents: Equatable {
         case (.number(let lhs), .number(let rhs)): return lhs == rhs
         case (.string(let lhs), .string(let rhs)): return lhs == rhs
         case (.bool(let lhs), .bool(let rhs)): return lhs == rhs
-        case(.null, .null): return true
+        case (.null, .null): return true
         default: return false
         }
     }

--- a/LastMilePerformanceTests/CollectionTests.swift
+++ b/LastMilePerformanceTests/CollectionTests.swift
@@ -49,8 +49,6 @@ extension Element: APIDecodable {
 
 
 class CollectionTests: XCTestCase {
-    let arrayCount = 100
-    let pairCount = 100
     var array: [Element]!
     var dict: [String: Element]!
     var arrayJSONData: Data!


### PR DESCRIPTION
- Run performance tests in the Release config so they more accurately represent real-world production performance
- Re-establish baseline times