### PR TITLE
Fix Playground compile errors on Xcode 12

### DIFF
--- a/LastMile.playground/Contents.swift
+++ b/LastMile.playground/Contents.swift
@@ -6,9 +6,9 @@ import LastMile
 // https://github.com/jbelkins/LastMile-iOS
 
 
-// For this playground to run correctly,
-// you may have to build the framework with
-// command-B first.
+// For this playground to run correctly on Xcode 12,
+// select the "LastMile" scheme,
+// then press the playground's Run button.
 
 struct Record {
     let id: Int

--- a/LastMile.playground/contents.xcplayground
+++ b/LastMile.playground/contents.xcplayground
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<playground version='5.0' target-platform='ios'>
+<playground version='5.0' target-platform='ios' buildActiveScheme='true'>
     <timeline fileName='timeline.xctimeline'/>
 </playground>


### PR DESCRIPTION
Update the setting & instructions for running LastMile in the playground.