### PR TITLE
Add performance test baselines for running on Mac

### DIFF
--- a/LastMile.xcodeproj/xcshareddata/xcbaselines/036F0261229F12E200991283.xcbaseline/EEBCD24D-1813-450A-94A0-82AD470FB39B.plist
+++ b/LastMile.xcodeproj/xcshareddata/xcbaselines/036F0261229F12E200991283.xcbaseline/EEBCD24D-1813-450A-94A0-82AD470FB39B.plist
@@ -1,0 +1,132 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>classNames</key>
+	<dict>
+		<key>CollectionTests</key>
+		<dict>
+			<key>test_LastMileArray100()</key>
+			<dict>
+				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
+				<dict>
+					<key>baselineAverage</key>
+					<real>0.0023277</real>
+					<key>baselineIntegrationDisplayName</key>
+					<string>Oct 1, 2020 at 12:45:33 PM</string>
+				</dict>
+			</dict>
+			<key>test_LastMileArray1000()</key>
+			<dict>
+				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
+				<dict>
+					<key>baselineAverage</key>
+					<real>0.021815</real>
+					<key>baselineIntegrationDisplayName</key>
+					<string>Oct 1, 2020 at 12:45:33 PM</string>
+				</dict>
+			</dict>
+			<key>test_LastMileArray10000()</key>
+			<dict>
+				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
+				<dict>
+					<key>baselineAverage</key>
+					<real>0.22163</real>
+					<key>baselineIntegrationDisplayName</key>
+					<string>Oct 1, 2020 at 12:45:33 PM</string>
+				</dict>
+			</dict>
+			<key>test_LastMileDict100()</key>
+			<dict>
+				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
+				<dict>
+					<key>baselineAverage</key>
+					<real>0.002715</real>
+					<key>baselineIntegrationDisplayName</key>
+					<string>Oct 1, 2020 at 12:45:33 PM</string>
+				</dict>
+			</dict>
+			<key>test_LastMileDict1000()</key>
+			<dict>
+				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
+				<dict>
+					<key>baselineAverage</key>
+					<real>0.024925</real>
+					<key>baselineIntegrationDisplayName</key>
+					<string>Oct 1, 2020 at 12:45:33 PM</string>
+				</dict>
+			</dict>
+			<key>test_LastMileDict10000()</key>
+			<dict>
+				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
+				<dict>
+					<key>baselineAverage</key>
+					<real>0.25482</real>
+					<key>baselineIntegrationDisplayName</key>
+					<string>Oct 1, 2020 at 12:45:33 PM</string>
+				</dict>
+			</dict>
+			<key>test_SwiftArray100()</key>
+			<dict>
+				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
+				<dict>
+					<key>baselineAverage</key>
+					<real>0.0014533</real>
+					<key>baselineIntegrationDisplayName</key>
+					<string>Oct 1, 2020 at 12:45:33 PM</string>
+				</dict>
+			</dict>
+			<key>test_SwiftArray1000()</key>
+			<dict>
+				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
+				<dict>
+					<key>baselineAverage</key>
+					<real>0.010156</real>
+					<key>baselineIntegrationDisplayName</key>
+					<string>Oct 1, 2020 at 12:45:33 PM</string>
+				</dict>
+			</dict>
+			<key>test_SwiftArray10000()</key>
+			<dict>
+				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
+				<dict>
+					<key>baselineAverage</key>
+					<real>0.10256</real>
+					<key>baselineIntegrationDisplayName</key>
+					<string>Oct 1, 2020 at 12:45:33 PM</string>
+				</dict>
+			</dict>
+			<key>test_SwiftDict100()</key>
+			<dict>
+				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
+				<dict>
+					<key>baselineAverage</key>
+					<real>0.0012262</real>
+					<key>baselineIntegrationDisplayName</key>
+					<string>Oct 1, 2020 at 12:45:33 PM</string>
+				</dict>
+			</dict>
+			<key>test_SwiftDict1000()</key>
+			<dict>
+				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
+				<dict>
+					<key>baselineAverage</key>
+					<real>0.012296</real>
+					<key>baselineIntegrationDisplayName</key>
+					<string>Oct 1, 2020 at 12:45:33 PM</string>
+				</dict>
+			</dict>
+			<key>test_SwiftDict10000()</key>
+			<dict>
+				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
+				<dict>
+					<key>baselineAverage</key>
+					<real>0.12831</real>
+					<key>baselineIntegrationDisplayName</key>
+					<string>Oct 1, 2020 at 12:45:33 PM</string>
+				</dict>
+			</dict>
+		</dict>
+	</dict>
+</dict>
+</plist>

--- a/LastMile.xcodeproj/xcshareddata/xcbaselines/036F0261229F12E200991283.xcbaseline/Info.plist
+++ b/LastMile.xcodeproj/xcshareddata/xcbaselines/036F0261229F12E200991283.xcbaseline/Info.plist
@@ -97,6 +97,30 @@
 				<string>com.apple.platform.iphonesimulator</string>
 			</dict>
 		</dict>
+		<key>EEBCD24D-1813-450A-94A0-82AD470FB39B</key>
+		<dict>
+			<key>localComputer</key>
+			<dict>
+				<key>busSpeedInMHz</key>
+				<integer>100</integer>
+				<key>cpuCount</key>
+				<integer>1</integer>
+				<key>cpuKind</key>
+				<string>Quad-Core Intel Core i7</string>
+				<key>cpuSpeedInMHz</key>
+				<integer>2300</integer>
+				<key>logicalCPUCoresPerPackage</key>
+				<integer>8</integer>
+				<key>modelCode</key>
+				<string>Macmini6,2</string>
+				<key>physicalCPUCoresPerPackage</key>
+				<integer>4</integer>
+				<key>platformIdentifier</key>
+				<string>com.apple.platform.macosx</string>
+			</dict>
+			<key>targetArchitecture</key>
+			<string>x86_64</string>
+		</dict>
 		<key>FEF9307A-D6B7-4D22-8928-163CC0C2A5BD</key>
 		<dict>
 			<key>localComputer</key>


### PR DESCRIPTION
Add baselines for four-core i7-based Mac.